### PR TITLE
Update react-scripts to avoid error

### DIFF
--- a/react-challenge/package.json
+++ b/react-challenge/package.json
@@ -12,7 +12,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "3.3.0",
+    "react-scripts": "^3.4.0",
     "react-select": "^3.0.8"
   },
   "scripts": {


### PR DESCRIPTION
Was receiving this error on `npm start`: 
`TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined`

The fix was to update `react-scripts` to `3.4.0`, I can confirm this resolved the error.